### PR TITLE
Adding RMI-I2C support, pending interrupt implement;

### DIFF
--- a/VoodooRMI.xcodeproj/project.pbxproj
+++ b/VoodooRMI.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6F37CAE424BD89A20000114C /* RMII2C.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6F37CAE324BD89A20000114C /* RMII2C.cpp */; };
 		A41323E82492077C00907B0D /* Configuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A41323E62492077C00907B0D /* Configuration.cpp */; };
 		A41323E92492077C00907B0D /* Configuration.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A41323E72492077C00907B0D /* Configuration.hpp */; };
 		A4435AF0248F8AD80083404C /* ButtonDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A4435AEE248F8AD80083404C /* ButtonDevice.cpp */; };
@@ -40,6 +41,7 @@
 
 /* Begin PBXFileReference section */
 		2850FFBC24904435000FA6BC /* PS2.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PS2.hpp; sourceTree = "<group>"; };
+		6F37CAE324BD89A20000114C /* RMII2C.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RMII2C.cpp; sourceTree = "<group>"; };
 		A41323E62492077C00907B0D /* Configuration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Configuration.cpp; sourceTree = "<group>"; };
 		A41323E72492077C00907B0D /* Configuration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Configuration.hpp; sourceTree = "<group>"; };
 		A4435AEE248F8AD80083404C /* ButtonDevice.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ButtonDevice.cpp; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 			children = (
 				A4560EEB247F32600009CBE0 /* RMITransport.hpp */,
 				A4560F0B247F406F0009CBE0 /* RMISMBus.cpp */,
+				6F37CAE324BD89A20000114C /* RMII2C.cpp */,
 			);
 			path = Transports;
 			sourceTree = "<group>";
@@ -304,6 +307,7 @@
 				A4560EFC247F32760009CBE0 /* F11.cpp in Sources */,
 				A4560F00247F32760009CBE0 /* F30.cpp in Sources */,
 				A4435AF0248F8AD80083404C /* ButtonDevice.cpp in Sources */,
+				6F37CAE424BD89A20000114C /* RMII2C.cpp in Sources */,
 				A4560EFD247F32760009CBE0 /* F12.cpp in Sources */,
 				A4560EF9247F32760009CBE0 /* F01.cpp in Sources */,
 				A4560EE1247F2A660009CBE0 /* RMI_2D_Sensor.cpp in Sources */,

--- a/VoodooRMI/Functions/F12.cpp
+++ b/VoodooRMI/Functions/F12.cpp
@@ -220,7 +220,7 @@ IOReturn F12::message(UInt32 type, IOService *provider, void *argument)
             getReport();
             break;
         case kHandleRMIClickpadSet:
-            clickpadState = !!(argument);
+            messageClient(type, sensor, argument);
             break;
         case kHandleRMITrackpoint:
             uint64_t timestamp;

--- a/VoodooRMI/Functions/F12.hpp
+++ b/VoodooRMI/Functions/F12.hpp
@@ -65,7 +65,6 @@ private:
     RMIBus *rmiBus;
     IOService *voodooInputInstance {nullptr};
     
-    bool clickpadState {false};
     bool pressureLock {false};
     bool touchpadEnable {true};
     bool forceTouchEmulation {true};

--- a/VoodooRMI/Functions/F30.cpp
+++ b/VoodooRMI/Functions/F30.cpp
@@ -115,7 +115,21 @@ int F30::rmi_f30_initialize()
     has_gpio_driver_control = buf[0] & RMI_F30_HAS_GPIO_DRV_CTL;
     has_mech_mouse_btns = buf[0] & RMI_F30_HAS_MECH_MOUSE_BTNS;
     gpioled_count = buf[1] & RMI_F30_GPIO_LED_COUNT;
-    
+
+    OSDictionary * attribute = OSDictionary::withCapacity(8);
+    attribute->setObject("extended_pattern", has_extended_pattern ? kOSBooleanTrue : kOSBooleanFalse);
+    attribute->setObject("mappable_buttons", has_mappable_buttons ? kOSBooleanTrue : kOSBooleanFalse);
+    attribute->setObject("led", has_led ? kOSBooleanTrue : kOSBooleanFalse);
+    attribute->setObject("gpio", has_gpio ? kOSBooleanTrue : kOSBooleanFalse);
+    attribute->setObject("haptic", has_haptic ? kOSBooleanTrue : kOSBooleanFalse);
+    attribute->setObject("gpio_driver_control", has_gpio_driver_control ? kOSBooleanTrue : kOSBooleanFalse);
+    attribute->setObject("mech_mouse_btns", has_mech_mouse_btns ? kOSBooleanTrue : kOSBooleanFalse);
+    OSNumber *count = OSNumber::withNumber(gpioled_count, 8);
+    attribute->setObject("gpioled_count", count);
+    setProperty("Attibute", attribute);
+    OSSafeReleaseNULL(count);
+    OSSafeReleaseNULL(attribute);
+
     register_count = DIV_ROUND_UP(gpioled_count, 8);
     
     if (has_gpio && has_led)
@@ -277,7 +291,10 @@ void F30::rmi_f30_report_button()
         mask = key_down << (key_code - 1);
         
         if (numButtons == 1 && i == clickpad_index) {
-            rmiBus->notify(kHandleRMIClickpadSet, key_down);
+            if (clickpadState != key_down) {
+                rmiBus->notify(kHandleRMIClickpadSet, key_down);
+                clickpadState = key_down;
+            }
             continue;
         }
         

--- a/VoodooRMI/Functions/F30.hpp
+++ b/VoodooRMI/Functions/F30.hpp
@@ -85,6 +85,7 @@ private:
     uint8_t clickpad_index {0};
     uint8_t numButtons {0};
     
+    bool clickpadState {false};
     uint8_t register_count;
     
     /* Control Register Data */

--- a/VoodooRMI/Info.plist
+++ b/VoodooRMI/Info.plist
@@ -50,6 +50,36 @@
 			<key>CFBundleIdentifier</key>
 			<string>com.1Revenger1.VoodooRMI</string>
 		</dict>
+		<key>RMII2CDevice</key>
+		<dict>
+			<key>Configuration</key>
+			<dict>
+				<key>MinYDiffThumbDetection</key>
+				<integer>200</integer>
+				<key>ForceTouchEmulation</key>
+				<true/>
+				<key>ForceTouchMinPressure</key>
+				<integer>90</integer>
+				<key>DisableWhileTypingTimeout</key>
+				<integer>100</integer>
+				<key>TrackstickMultiplier</key>
+				<integer>20</integer>
+				<key>TrackstickScrollMultiplierX</key>
+				<integer>20</integer>
+				<key>TrackstickScrollMultiplierY</key>
+				<integer>20</integer>
+				<key>TrackstickDeadzone</key>
+				<integer>1</integer>
+			</dict>
+			<key>IOProbeScore</key>
+			<integer>2910</integer>
+			<key>IOProviderClass</key>
+			<string>RMII2C</string>
+			<key>IOClass</key>
+			<string>RMIBus</string>
+			<key>CFBundleIdentifier</key>
+			<string>com.1Revenger1.VoodooRMI</string>
+		</dict>
 		<key>RMISMBus</key>
 		<dict>
 			<key>IOProbeScore</key>
@@ -61,6 +91,22 @@
 			<key>CFBundleIdentifier</key>
 			<string>com.1Revenger1.VoodooRMI</string>
 		</dict>
+		<key>RMII2C</key>
+		<dict>
+			<key>IOProbeScore</key>
+			<integer>500</integer>
+			<key>IOProviderClass</key>
+			<string>VoodooI2CDeviceNub</string>
+			<key>IOClass</key>
+			<string>RMII2C</string>
+			<key>IOPropertyMatch</key>
+			<dict>
+				<key>name</key>
+				<string>SYNA2B31</string>
+			</dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.1Revenger1.VoodooRMI</string>
+		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2020 1Revenger1. All rights reserved.</string>
@@ -68,6 +114,8 @@
 	<dict>
 		<key>de.leo-labs.VoodooSMBus</key>
 		<string>2.1</string>
+		<key>com.alexandred.VoodooI2C</key>
+		<string>2.0</string>
 		<key>com.apple.kpi.iokit</key>
 		<string>18.5</string>
 		<key>com.apple.kpi.libkern</key>

--- a/VoodooRMI/RMIBus.cpp
+++ b/VoodooRMI/RMIBus.cpp
@@ -230,24 +230,33 @@ int RMIBus::rmi_register_function(rmi_function *fn) {
     RMIFunction * function;
     
     switch(fn->fd.function_number) {
-        case 0x01:
+        case 0x01: /* device control */
             function = OSDynamicCast(RMIFunction, OSTypeAlloc(F01));
             break;
-        case 0x03:
+        case 0x03: /* PS/2 pass-through */
             function = OSDynamicCast(RMIFunction, OSTypeAlloc(F03));
             break;
-        case 0x11:
+        case 0x11: /* multifinger pointing */
             function = OSDynamicCast(RMIFunction, OSTypeAlloc(F11));
             break;
-        case 0x12:
+        case 0x12: /* multifinger pointing */
             function = OSDynamicCast(RMIFunction, OSTypeAlloc(F12));
             break;
-        case 0x30:
+        case 0x30: /* GPIO and LED controls */
             function = OSDynamicCast(RMIFunction, OSTypeAlloc(F30));
             break;
+//        case 0x09: /* self test (aka BIST) */
+//        case 0x17: /* pointing sticks */
+//        case 0x19: /* capacitive buttons */
+//        case 0x1A: /* simple capacitive buttons */
+//        case 0x21: /* force sensing */
+//        case 0x32: /* timer */
+        case 0x34: /* device reflash */
+//        case 0x36: /* auxiliary ADC */
         case 0x3A:
-        case 0x54:
-        case 0x55:
+//        case 0x41: /* active pen pointing */
+        case 0x54: /* analog data reporting */
+        case 0x55: /* Sensor tuning */
             IOLog("F%X not implemented\n", fn->fd.function_number);
             return 0;
         default:

--- a/VoodooRMI/RMIBus.hpp
+++ b/VoodooRMI/RMIBus.hpp
@@ -67,6 +67,7 @@ public:
 private:
     OSDictionary *config;
     void handleHostNotify();
+    void handleHostNotifyI2C();
 };
     
 #endif /* RMIBus_h */

--- a/VoodooRMI/Transports/RMII2C.cpp
+++ b/VoodooRMI/Transports/RMII2C.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2020 Zhen
  * Ported to macOS from linux kernel, original source at
  * https://github.com/torvalds/linux/blob/master/drivers/input/rmi4/rmi_i2c.c
+ * https://github.com/torvalds/linux/blob/master/drivers/hid/hid-rmi.c
  * and code written by Alexandre, CoolStar and Kishor Prins
  * https://github.com/VoodooI2C/VoodooI2CSynaptics
  *
@@ -88,25 +89,14 @@ bool RMII2C::start(IOService *provider)
             goto exit;
         }
         work_loop->addEventSource(interrupt_simulator);
-//        interrupt_simulator->setTimeoutMS(200);
         IOLog("%s: Polling mode initialisation succeeded.", getName());
-        setProperty("Mode", "Polling");
+        setProperty("Interrupt mode", "Polling");
     } else {
         work_loop->addEventSource(interrupt_source);
-//        interrupt_source->enable();
         IOLog("%s: running on interrupt mode.", getName());
-        setProperty("Mode", "Interrupt");
+        setProperty("Interrupt mode", "Native");
     }
-    setProperty("Interrupt", false);
-
-    client = getClient();
-    if (!client) {
-        IOLog("%s: Could not get client\n", getName());
-//        goto exit;
-    }
-
     setProperty("VoodooI2CServices Supported", kOSBooleanTrue);
-    reading = false;
     return res;
 exit:
     releaseResources();
@@ -131,13 +121,6 @@ void RMII2C::releaseResources() {
     OSSafeReleaseNULL(interrupt_simulator);
     OSSafeReleaseNULL(interrupt_source);
     OSSafeReleaseNULL(work_loop);
-    
-//    if (device_nub) {
-//        if (device_nub->isOpen(this))
-//            device_nub->close(this);
-//        device_nub->release();
-//        device_nub = NULL;
-//    }
     OSSafeReleaseNULL(device_nub);
 
     IOLockFree(page_mutex);
@@ -150,13 +133,18 @@ void RMII2C::stop(IOService *device) {
 
 int RMII2C::rmi_set_page(u8 page)
 {
-    uint8_t writeReport[25] = {0x25, 0x00, 0x17, 0x00};
+    // simplified version of rmi_write_report, hid_hw_output_report, i2c_hid_output_report,
+    // i2c_hid_output_raw_report, i2c_hid_set_or_send_report and __i2c_hid_command
+    u8 writeReport[8] = {
+        0x25,  // outputRegister & 0xFF; wOutputRegister
+        0x00,  // outputRegister >> 8;
+        0x06,  // size & 0xFF
+        0x00,  // size >> 8
+        RMI_WRITE_REPORT_ID,
+        0x01,
+        RMI_PAGE_SELECT_REGISTER,
+        page };
 
-    writeReport[4] = RMI_WRITE_REPORT_ID;
-    writeReport[5] = 1;
-    writeReport[6] = RMI_PAGE_SELECT_REGISTER;
-    writeReport[7] = page;
-    
     if (device_nub->writeI2C(writeReport, sizeof(writeReport)) != kIOReturnSuccess) {
         IOLog("%s: failed to write request output report\n", getName());
         return -1;
@@ -167,19 +155,20 @@ int RMII2C::rmi_set_page(u8 page)
 }
 
 int RMII2C::rmi_set_mode(u8 mode) {
-    u8 command[] = { 0x22, 0x00, 0x3f, 0x03, 0x0f, 0x23, 0x00, 0x04, 0x00, RMI_SET_RMI_MODE_REPORT_ID, mode }; //magic bytes from Linux
-//    u8 command[] = {
-//        0x22, // registerIndex : wCommandRegister
-//        0x00, // registerIndex+1
-//        0x3f, // reportID | reportType << 4; reportType: 0x03 for HID_FEATURE_REPORT (kIOHIDReportTypeFeature) ; 0x02 for HID_OUTPUT_REPORT (kIOHIDReportTypeOutput)
-//        0x03, // hid_set_report_cmd =    { I2C_HID_CMD(0x03) };
-//        0x0f, // report_id -> RMI_SET_RMI_MODE_REPORT_ID
-//        0x23, // dataRegister & 0xFF; wDataRegister
-//        0x00, // dataRegister >> 8;
-//        0x04, // size & 0xFF; 2 + reportID + buf (reportID excluded)
-//        0x00, // size >> 8;
-//        RMI_SET_RMI_MODE_REPORT_ID, // report_id = buf[0];
-//        mode };
+    u8 command[] = {
+        0x22, // registerIndex : wCommandRegister
+        0x00, // registerIndex+1
+        0x3f, // reportID | reportType << 4;
+              // reportType: 0x03 for HID_FEATURE_REPORT (kIOHIDReportTypeFeature) ; 0x02 for HID_OUTPUT_REPORT (kIOHIDReportTypeOutput)
+        0x03, // hid_set_report_cmd =    { I2C_HID_CMD(0x03) };
+        0x0f, // report_id -> RMI_SET_RMI_MODE_REPORT_ID
+        0x23, // dataRegister & 0xFF; wDataRegister
+        0x00, // dataRegister >> 8;
+        0x04, // size & 0xFF; 2 + reportID + buf (reportID excluded)
+        0x00, // size >> 8;
+        RMI_SET_RMI_MODE_REPORT_ID, // report_id = buf[0];
+        mode };
+
     if (device_nub->writeI2C(command, sizeof(command)) != kIOReturnSuccess)
         return -1;
     else
@@ -187,136 +176,124 @@ int RMII2C::rmi_set_mode(u8 mode) {
 }
 
 int RMII2C::readBlock(u16 rmiaddr, u8 *databuff, size_t len) {
-    int ret = 0;
-    uint8_t writeReport[25] = {0x25, 0x00, 0x17, 0x00};
-//    uint8_t writeReport[25] = {
-//        0x25,
-//        0x00,
-//        0x17,
-//        0x00}; // hid_no_cmd =        { .length = 0 };
+    int retval = 0;
+    u8 writeReport[10] = {
+        0x25,  // outputRegister & 0xFF; wOutputRegister
+        0x00,  // outputRegister >> 8;
+        0x08,  // size & 0xFF; 2 + reportID + buf (reportID excluded)
+        0x00,  // size >> 8;
+        RMI_READ_ADDR_REPORT_ID,
+        0x00,  // /* old 1 byte read count */
+        (u8) (rmiaddr & 0xFF),
+        (u8) (rmiaddr >> 8),
+        (u8) (len & 0xFF),
+        (u8) (len >> 8) };
+
     // maybe no need to strip the I2C (and RMI_READ_DATA_REPORT_ID) header?
     u8 *i2cInput = new u8[len+4];
     memset(databuff, 0, len);
 
     IOLockLock(page_mutex);
     if (RMI_I2C_PAGE(rmiaddr) != page) {
-        ret = rmi_set_page(RMI_I2C_PAGE(rmiaddr));
-        if (ret < 0)
+        retval = rmi_set_page(RMI_I2C_PAGE(rmiaddr));
+        if (retval < 0)
             goto exit;
     }
     
-    writeReport[4] = RMI_READ_ADDR_REPORT_ID;
-//    writeReport[5] = 0;
-    writeReport[6] = rmiaddr & 0xFF;
-    writeReport[7] = (rmiaddr >> 8) & 0xFF;
-    writeReport[8] = len & 0xFF;
-    writeReport[9] = (len >> 8) & 0xFF;
-
     if (device_nub->writeI2C(writeReport, sizeof(writeReport)) != kIOReturnSuccess) {
         IOLog("%s: failed to read request output report\n", getName());
-        ret = -1;
+        retval = -1;
         goto exit;
     }
 
     if (device_nub->readI2C(i2cInput, len+4) != kIOReturnSuccess) {
         IOLog("%s: failed to read I2C input\n", getName());
-        ret = -1;
+        retval = -1;
         goto exit;
     }
 
-    if (i2cInput[2] == RMI_READ_DATA_REPORT_ID) {
-        memcpy(databuff, i2cInput+4, len);
+    if (i2cInput[2] != RMI_READ_DATA_REPORT_ID) {
+        IOLog("%s: RMI_READ_DATA_REPORT_ID mismatch\n", getName());
+        retval = -1;
+        goto exit;
     }
+
+    memcpy(databuff, i2cInput+4, len);
 exit:
 //    IOLog("read %zd bytes at %#06x: %d (%*ph)\n", len, rmiaddr, ret, (int)len, databuff);
     IOLockUnlock(page_mutex);
-    return ret;
+    return retval;
 }
 
 int RMII2C::blockWrite(u16 rmiaddr, u8 *buf, size_t len) {
-    int ret;
-    uint8_t writeReport[25] = {0x25, 0x00, 0x17, 0x00};
+    int retval = 0;
+    u8 *writeReport = new u8[len+8] {
+        0x25,  // outputRegister & 0xFF; wOutputRegister
+        0x00,  // outputRegister >> 8;
+        (u8) ((len + 6) & 0xFF),  // size & 0xFF; 2 + reportID + buf (reportID excluded)
+        (u8) ((len + 6) >> 8),  // size >> 8;
+        RMI_WRITE_REPORT_ID,
+        (u8) len,
+        (u8) (rmiaddr & 0xFF),
+        (u8) (rmiaddr >> 8) };
 
     IOLockLock(page_mutex);
     if (RMI_I2C_PAGE(rmiaddr) != page) {
-        ret = rmi_set_page(RMI_I2C_PAGE(rmiaddr));
-        if (ret < 0)
+        retval = rmi_set_page(RMI_I2C_PAGE(rmiaddr));
+        if (retval < 0)
             goto exit;
     }
     
-    writeReport[4] = RMI_WRITE_REPORT_ID;
-    writeReport[5] = len;
-    writeReport[6] = rmiaddr & 0xFF;
-    writeReport[7] = (rmiaddr >> 8) & 0xFF;
-
     memcpy(writeReport+8, buf, len);
 
-    if (device_nub->writeI2C(writeReport, sizeof(writeReport)) != kIOReturnSuccess) {
+    if (device_nub->writeI2C(writeReport, len+8) != kIOReturnSuccess) {
         IOLog("%s: failed to write request output report\n", getName());
-        ret = -1;
+        retval = -1;
         goto exit;
     }
-    ret = 0;
+    retval = 0;
     
 exit:
 //    IOLog("write %zd bytes at %#06x: %d (%*ph)\n", len, rmiaddr, ret, (int)len, buf);
     IOLockUnlock(page_mutex);
-    return ret;
-}
-
-int RMII2C::rmi_write_report(u8 *report, size_t report_size) {
-    u8 command[25];
-    command[0] = 0x25;
-    command[1] = 0x00;
-    command[2] = 0x17;
-    command[3] = 0x00;
-    for (int i = 0; i < report_size; i++) {
-        command[i + 4] = report[i];
-    }
-    IOReturn ret = device_nub->writeI2C(command, sizeof(command));
-    
-    if (ret != kIOReturnSuccess)
-        return -1;
-    else
-        return 0;
+    return retval;
 }
 
 void RMII2C::interruptOccured(OSObject *owner, IOInterruptEventSource *src, int intCount) {
     if (reading || !client)// || !awake)
         return;
 
-    command_gate->attemptAction(OSMemberFunctionCast(IOCommandGate::Action, this, &RMII2C::getInputReport));
+    command_gate->attemptAction(OSMemberFunctionCast(IOCommandGate::Action, this, &RMII2C::notifyClient));
 }
 
-void RMII2C::getInputReport() {
+void RMII2C::notifyClient() {
     // Do we really need it in command gate?
     reading = true;
     messageClient(kIOMessageVoodooI2CHostNotify, client);
     reading = false;
-exit:
-    return;
 }
 
 void RMII2C::simulateInterrupt(OSObject* owner, IOTimerEventSource* timer) {
     interruptOccured(owner, NULL, 0);
-    if (polling) {
+    if (polling)
         interrupt_simulator->setTimeoutMS(INTERRUPT_SIMULATOR_TIMEOUT);
-    }
 }
 
 bool RMII2C::setInterrupt(bool enable) {
     // interrupt will only be enabled after client update
-    if (!client)
+    while (!client) {
         client = getClient();
+        IOSleep(500);
+    }
 
     if (enable) {
         reading = false;
         if (!interrupt_source) {
             interrupt_simulator->setTimeoutMS(INTERRUPT_SIMULATOR_INTERVAL);
             polling = true;
-        }
-        else
+        } else {
             interrupt_source->enable();
+        }
     } else {
         reading = true;
         if (!interrupt_source)
@@ -324,9 +301,6 @@ bool RMII2C::setInterrupt(bool enable) {
         else
             interrupt_source->disable();
     }
-
-    IOLog("%s: interrupt %s", getName(), enable ? "enabled" : "disabled");
-    setProperty("Interrupt", enable);
 
     return true;
 }

--- a/VoodooRMI/Transports/RMII2C.cpp
+++ b/VoodooRMI/Transports/RMII2C.cpp
@@ -1,0 +1,286 @@
+/* SPDX-License-Identifier: GPL-2.0-only
+ * Copyright (c) 2020 Zhen
+ * Ported to macOS from linux kernel, original source at
+ * https://github.com/torvalds/linux/blob/master/drivers/input/rmi4/rmi_i2c.c
+ *
+ * Copyright (c) 2011-2016 Synaptics Incorporated
+ * Copyright (c) 2011 Unixphere
+ */
+
+#include "RMITransport.hpp"
+
+//OSDefineMetaClassAndStructors(RMITransport, IOService)
+OSDefineMetaClassAndStructors(RMII2C, RMITransport)
+
+RMII2C *RMII2C::probe(IOService *provider, SInt32 *score)
+{
+    int error;
+
+    OSData *data;
+    data = OSDynamicCast(OSData, provider->getProperty("name"));
+    IOLog("%s: RMII2C probing %s\n", getName(), data->getBytesNoCopy());
+
+    IOService *service = super::probe(provider, score);
+    if(!service) {
+        IOLog("%s: Failed to probe provider\n", getName());
+        return NULL;
+    }
+    
+    device_nub = OSDynamicCast(VoodooI2CDeviceNub, provider);
+    if (!device_nub) {
+        IOLog("%s: Could not cast nub\n", getName());
+        return NULL;
+    }
+    error = rmi_set_mode(RMI_MODE_ATTN_REPORTS);
+    if (error) {
+        IOLog("%s: Failed to set mode\n", getName());
+        return NULL;
+    }
+
+    page_mutex = IOLockAlloc();
+    IOLockLock(page_mutex);
+    /*
+     * Setting the page to zero will (a) make sure the PSR is in a
+     * known state, and (b) make sure we can talk to the device.
+     */
+    error = rmi_set_page(0);
+    IOLockUnlock(page_mutex);
+    if (error) {
+        IOLog("%s: Failed to set page select to 0\n", getName());
+        return NULL;
+    }
+    return this;
+}
+
+bool RMII2C::start(IOService *provider)
+{
+    bool res = super::start(provider);
+    registerService();
+
+    work_loop = getWorkLoop();
+    
+    if (!work_loop) {
+        IOLog("%s: Could not get work loop\n", getName());
+        goto exit;
+    }
+
+    command_gate = IOCommandGate::commandGate(this);
+    if (!command_gate || (work_loop->addEventSource(command_gate) != kIOReturnSuccess)) {
+        IOLog("%s: Could not open command gate\n", getName());
+        goto exit;
+    }
+
+    /* Implementation of polling */
+    interrupt_source = IOInterruptEventSource::interruptEventSource(this, OSMemberFunctionCast(IOInterruptEventAction, this, &RMII2C::interruptOccured), device_nub, 0);
+    if (!interrupt_source) {
+        IOLog("%s: Could not get interrupt event source\n, trying to fallback on polling.", getName());
+        interrupt_simulator = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &RMII2C::simulateInterrupt));
+        if (!interrupt_simulator) {
+            IOLog("%s: Could not get timer event source\n", getName());
+            goto exit;
+        }
+        work_loop->addEventSource(interrupt_simulator);
+        interrupt_simulator->setTimeoutMS(200);
+        IOLog("%s: Polling mode initialisation succeeded.", getName());
+    } else {
+        work_loop->addEventSource(interrupt_source);
+        interrupt_source->enable();
+        IOLog("%s: running on interrupt mode.", getName());
+    }
+
+    client = getClient();
+    if (!client) {
+        IOLog("%s: Could not get client\n", getName());
+        goto exit;
+    }
+
+    setProperty("VoodooI2CServices Supported", kOSBooleanTrue);
+    reading = false;
+    return res;
+exit:
+    releaseResources();
+    return false;
+}
+
+void RMII2C::releaseResources() {
+    if (command_gate) {
+        command_gate->disable();
+        work_loop->removeEventSource(command_gate);
+    }
+    if (interrupt_source) {
+        interrupt_source->disable();
+        work_loop->removeEventSource(interrupt_source);
+    }
+    if (interrupt_simulator) {
+        interrupt_simulator->disable();
+        work_loop->removeEventSource(interrupt_simulator);
+    }
+    
+    OSSafeReleaseNULL(command_gate);
+    OSSafeReleaseNULL(interrupt_simulator);
+    OSSafeReleaseNULL(interrupt_source);
+    OSSafeReleaseNULL(work_loop);
+    
+    if (device_nub) {
+        if (device_nub->isOpen(this))
+            device_nub->close(this);
+        device_nub->release();
+        device_nub = NULL;
+    }
+    
+    IOLockFree(page_mutex);
+}
+
+void RMII2C::stop(IOService *device) {
+    releaseResources();
+    super::stop(device);
+}
+
+int RMII2C::rmi_set_page(u8 page)
+{
+    uint8_t writeReport[25] = {0x25, 0x00, 0x17, 0x00};
+
+    writeReport[4] = RMI_WRITE_REPORT_ID;
+    writeReport[5] = 1;
+    writeReport[6] = RMI_PAGE_SELECT_REGISTER;
+    writeReport[7] = page;
+    
+    if (device_nub->writeI2C(writeReport, sizeof(writeReport)) != kIOReturnSuccess) {
+        IOLog("%s: failed to write request output report\n", getName());
+        return -1;
+    }
+
+    this->page = page;
+    return 0;
+}
+
+int RMII2C::rmi_set_mode(u8 mode) {
+    u8 command[] = { 0x22, 0x00, 0x3f, 0x03, 0x0f, 0x23, 0x00, 0x04, 0x00, RMI_SET_RMI_MODE_REPORT_ID, mode }; //magic bytes from Linux
+    IOReturn ret = device_nub->writeI2C(command, sizeof(command));
+    if (ret != kIOReturnSuccess)
+        return -1;
+    else
+        return 0;
+}
+
+int RMII2C::readBlock(u16 rmiaddr, u8 *databuff, size_t len) {
+    int ret = 0;
+    uint8_t writeReport[25] = {0x25, 0x00, 0x17, 0x00};
+
+    IOLockLock(page_mutex);
+    if (RMI_I2C_PAGE(rmiaddr) != page) {
+        ret = rmi_set_page(RMI_I2C_PAGE(rmiaddr));
+        if (ret < 0)
+            goto exit;
+    }
+    
+    writeReport[4] = RMI_READ_ADDR_REPORT_ID;
+//    writeReport[5] = 0;
+    writeReport[6] = rmiaddr & 0xFF;
+    writeReport[7] = (rmiaddr >> 8) & 0xFF;
+    writeReport[8] = len & 0xFF;
+    writeReport[9] = (len >> 8) & 0xFF;
+
+    if (device_nub->writeI2C(writeReport, sizeof(writeReport)) != kIOReturnSuccess) {
+        IOLog("%s: failed to read request output report\n", getName());
+        ret = -1;
+        goto exit;
+    }
+
+    uint8_t i2cInput[42];
+    
+    if (device_nub->readI2C(i2cInput, sizeof(i2cInput)) != kIOReturnSuccess) {
+        IOLog("%s: failed to read I2C input\n", getName());
+        ret = -1;
+        goto exit;
+    }
+
+    // TODO: simplifying
+    // IOLog("RMI Read Commence\n");
+    uint8_t rmiInput[40];
+    for (int i = 0; i < 40; i++) {
+        // IOLog("0x%x ", i2cInput[i]);
+        rmiInput[i] = i2cInput[i + 2];
+    }
+    // IOLog("\n");
+    // IOLog("RMI Read End\n");
+    if (rmiInput[0] == RMI_READ_DATA_REPORT_ID) {
+        for (int i = 0; i < len; i++) {
+            databuff[i] = rmiInput[i + 2];
+        }
+    }
+exit:
+//    IOLog("read %zd bytes at %#06x: %d (%*ph)\n", len, rmiaddr, ret, (int)len, databuff);
+    IOLockUnlock(page_mutex);
+    return ret;
+}
+
+int RMII2C::blockWrite(u16 rmiaddr, u8 *buf, size_t len) {
+    int ret;
+    uint8_t writeReport[25] = {0x25, 0x00, 0x17, 0x00};
+
+    IOLockLock(page_mutex);
+    if (RMI_I2C_PAGE(rmiaddr) != page) {
+        ret = rmi_set_page(RMI_I2C_PAGE(rmiaddr));
+        if (ret < 0)
+            goto exit;
+    }
+    
+    writeReport[4] = RMI_WRITE_REPORT_ID;
+    writeReport[5] = len;
+    writeReport[6] = rmiaddr & 0xFF;
+    writeReport[7] = (rmiaddr >> 8) & 0xFF;
+
+    memcpy(writeReport+8, buf, len);
+
+    if (device_nub->writeI2C(writeReport, sizeof(writeReport)) != kIOReturnSuccess) {
+        IOLog("%s: failed to write request output report\n", getName());
+        ret = -1;
+        goto exit;
+    }
+    ret = 0;
+    
+exit:
+//    IOLog("write %zd bytes at %#06x: %d (%*ph)\n", len, rmiaddr, ret, (int)len, buf);
+    IOLockUnlock(page_mutex);
+    return ret;
+}
+
+int RMII2C::rmi_write_report(u8 *report, size_t report_size) {
+    u8 command[25];
+    command[0] = 0x25;
+    command[1] = 0x00;
+    command[2] = 0x17;
+    command[3] = 0x00;
+    for (int i = 0; i < report_size; i++) {
+        command[i + 4] = report[i];
+    }
+    IOReturn ret = device_nub->writeI2C(command, sizeof(command));
+    
+    if (ret != kIOReturnSuccess)
+        return -1;
+    else
+        return 0;
+}
+
+void RMII2C::interruptOccured(OSObject *owner, IOInterruptEventSource *src, int intCount) {
+    if (reading || !client)// || !awake)
+        return;
+
+    command_gate->attemptAction(OSMemberFunctionCast(IOCommandGate::Action, this, &RMII2C::getInputReport));
+}
+
+void RMII2C::getInputReport() {
+    // Do we really need it in command gate?
+    reading = true;
+    // messageclient?
+    messageClient(kIOMessageVoodooSMBusHostNotify, client);
+    reading = false;
+    return;
+}
+
+void RMII2C::simulateInterrupt(OSObject* owner, IOTimerEventSource* timer) {
+    interruptOccured(owner, NULL, 0);
+    interrupt_simulator->setTimeoutMS(INTERRUPT_SIMULATOR_TIMEOUT);
+}
+

--- a/VoodooRMI/Transports/RMITransport.hpp
+++ b/VoodooRMI/Transports/RMITransport.hpp
@@ -132,12 +132,14 @@ public:
 
     int readBlock(u16 rmiaddr, u8 *databuff, size_t len) APPLE_KEXT_OVERRIDE;
     int blockWrite(u16 rmiaddr, u8 *buf, size_t len) APPLE_KEXT_OVERRIDE;
-    inline int reset() APPLE_KEXT_OVERRIDE {return rmi_set_mode(RMI_MODE_ATTN_REPORTS);};
+    inline int reset() APPLE_KEXT_OVERRIDE {
+        return rmi_set_mode(RMI_MODE_ATTN_REPORTS);
+    };
     bool setInterrupt(bool enable) APPLE_KEXT_OVERRIDE;
 
     void simulateInterrupt(OSObject* owner, IOTimerEventSource* timer);
     void interruptOccured(OSObject* owner, IOInterruptEventSource* src, int intCount);
-    void getInputReport();
+    void notifyClient();
 
 private:
     IOWorkLoop* work_loop;
@@ -154,7 +156,6 @@ private:
     IOLock *page_mutex;
     int page {0};
     
-    int rmi_write_report(u8 *report, size_t report_size);
     int rmi_set_page(u8 page);
     int rmi_set_mode(u8 mode);
 };


### PR DESCRIPTION
mute F34 unknown as not implemented, add some notes.

I'm not sure how to allow multiple provider or dependencies for OSBundleLibraries. Currently I have to comment out all reference for loading without VoodooSMBus. Or if some change will be made to the structure like separate transport plugins.

Now the driver can load and recognize F functions, and the interrupt on I2C side is available for both polling and native approach. So the remaining work is to message RMIBUS and set up forwarding there?

Closes #17 