### PR TITLE
Switch to evaluateDSM for getHIDDescriptorAddress; deprecate the usage of IOACPIFamily

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Linux:
   * Clover users can go inside the VoodooPS2 kext and remove VoodooPS2Trackpad/VoodooPS2Mouse from PlugIns folder.
 
 **I2C**
-* [VoodooI2C](https://github.com/VoodooI2C/VoodooI2C)
+* [VoodooI2C](https://github.com/VoodooI2C/VoodooI2C) 2.5 or newer is required
   * Follow their [Documentation](https://voodooi2c.github.io) to identify if you need GPIO pinning.
   * Polling mode should just work
 * If your device's ACPI name is not included below or marked as unknown, you may add it yourself and create a PR/issue

--- a/VoodooRMI/Transports/I2C/Info.plist
+++ b/VoodooRMI/Transports/I2C/Info.plist
@@ -46,7 +46,7 @@
 	<key>OSBundleLibraries</key>
 	<dict>
 		<key>com.alexandred.VoodooI2C</key>
-		<string>2.4.5</string>
+		<string>2.5</string>
 		<key>com.1Revenger1.VoodooRMI</key>
 		<string>1.0</string>
 		<key>com.apple.kpi.iokit</key>

--- a/VoodooRMI/Transports/I2C/Info.plist
+++ b/VoodooRMI/Transports/I2C/Info.plist
@@ -54,7 +54,7 @@
 	<key>OSBundleLibraries</key>
 	<dict>
 		<key>com.alexandred.VoodooI2C</key>
-		<string>2.0</string>
+		<string>2.4.5</string>
 		<key>com.1Revenger1.VoodooRMI</key>
 		<string>1.0</string>
 		<key>com.apple.kpi.iokit</key>
@@ -65,8 +65,6 @@
 		<string>18.5</string>
 		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>2.0</string>
-		<key>com.apple.iokit.IOACPIFamily</key>
-		<string>1.4</string>
 	</dict>
 </dict>
 </plist>

--- a/VoodooRMI/Transports/I2C/RMII2C.cpp
+++ b/VoodooRMI/Transports/I2C/RMII2C.cpp
@@ -139,10 +139,10 @@ void RMII2C::releaseResources() {
     IOLockFree(page_mutex);
 }
 
-void RMII2C::stop(IOService *device) {
+void RMII2C::stop(IOService *provider) {
     releaseResources();
     PMstop();
-    super::stop(device);
+    super::stop(provider);
 }
 
 int RMII2C::rmi_set_page(u8 page) {
@@ -171,11 +171,11 @@ int RMII2C::rmi_set_page(u8 page) {
 
 IOReturn RMII2C::getHIDDescriptorAddress() {
     IOReturn ret;
-    OSObject* obj = nullptr;
+    OSObject *obj = nullptr;
 
     ret = device_nub->evaluateDSM(I2C_DSM_HIDG, HIDG_DESC_INDEX, &obj);
     if (ret == kIOReturnSuccess) {
-        OSNumber* number = OSDynamicCast(OSNumber, obj);
+        OSNumber *number = OSDynamicCast(OSNumber, obj);
         if (number != nullptr) {
             wHIDDescRegister = number->unsigned16BitValue();
             setProperty("HIDDescriptorAddress", wHIDDescRegister, 16);

--- a/VoodooRMI/Transports/I2C/RMII2C.hpp
+++ b/VoodooRMI/Transports/I2C/RMII2C.hpp
@@ -74,7 +74,7 @@ public:
 
     RMII2C *probe(IOService *provider, SInt32 *score) APPLE_KEXT_OVERRIDE;
     bool start(IOService *provider) APPLE_KEXT_OVERRIDE;
-    void stop(IOService* device) APPLE_KEXT_OVERRIDE;
+    void stop(IOService *provider) APPLE_KEXT_OVERRIDE;
     IOReturn setPowerState(unsigned long powerState, IOService *whatDevice) APPLE_KEXT_OVERRIDE;
     bool handleOpen(IOService *forClient, IOOptionBits options, void *arg) APPLE_KEXT_OVERRIDE;
 


### PR DESCRIPTION
Maybe this PR can be merged after next VoodooI2C release?