### PR TITLE
Simplify check for palm rejection

### DIFF
--- a/VoodooRMI.xcodeproj/xcshareddata/xcschemes/VoodooRMI.xcscheme
+++ b/VoodooRMI.xcodeproj/xcshareddata/xcschemes/VoodooRMI.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/VoodooRMI.xcodeproj/xcshareddata/xcschemes/VoodooRMI.xcscheme
+++ b/VoodooRMI.xcodeproj/xcshareddata/xcschemes/VoodooRMI.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/VoodooRMI/Functions/F30.cpp
+++ b/VoodooRMI/Functions/F30.cpp
@@ -277,6 +277,8 @@ void F30::rmi_f30_report_button()
         // Key code is one above the value we need to bitwise shift left, as key code 0 is "Reserved" or "not present"
         mask = key_down << (key_code - 1);
         
+        IOLogDebug("Key %u is %s", key_code, key_down ? "Down": "Up");
+        
         if (numButtons == 1 && i == clickpad_index) {
             if (clickpadState != key_down) {
                  rmiBus->notify(kHandleRMIClickpadSet, key_down);
@@ -284,8 +286,6 @@ void F30::rmi_f30_report_button()
              }
             continue;
         }
-        
-        IOLogDebug("Key %u is %s", key_code, key_down ? "Down": "Up");
         
         if (i >= TRACKPOINT_RANGE_START &&
             i <= TRACKPOINT_RANGE_END) {

--- a/VoodooRMI/Info.plist
+++ b/VoodooRMI/Info.plist
@@ -27,9 +27,9 @@
 			<key>Configuration</key>
 			<dict>
 				<key>DisableWhileTrackpointTimeout </key>
-				<integer>2000</integer>
+				<integer>250</integer>
 				<key>DisableWhileTypingTimeout</key>
-				<integer>2000</integer>
+				<integer>250</integer>
 				<key>FingerMajorMinorDiffMax</key>
 				<integer>3</integer>
 				<key>MinYDiffThumbDetection</key>

--- a/VoodooRMI/RMI_2D_Sensor.cpp
+++ b/VoodooRMI/RMI_2D_Sensor.cpp
@@ -203,7 +203,6 @@ void RMI2DSensor::handleReport(RMI2DSensorReport *report)
             // Dissallow large objects
             transducer.isValid = !(discardRegions && checkInZone(transducer)) &&
                                  !invalidFinger[i] &&
-                                 obj.type != RMI_2D_OBJECT_INACCURATE &&
                                  obj.z < RMI_2D_MAX_Z &&
                                  // Accidental light brushes by the palm generally are not circular
                                  deltaWidth <= conf->fingerMajorMinorMax;


### PR DESCRIPTION
Fixes #100 

This is reverting some changes I made with a previous PR, while tuning some numbers. This specifically:
* Always compares wx/wy of a finger (Conditionally checking this seemed to cause weird issues)
* Reduce timeout while typing
* Reduce size of top box for trackpoint/top buttons
