### PR TITLE
Only add/remove interrupts during startup/shutdown

### DIFF
--- a/VoodooRMI/Transports/I2C/RMII2C.cpp
+++ b/VoodooRMI/Transports/I2C/RMII2C.cpp
@@ -130,13 +130,13 @@ void RMII2C::releaseResources() {
     if (command_gate) {
         work_loop->removeEventSource(command_gate);
     }
-    
+
     stopInterrupt();
-    
+
     if (interrupt_source) {
         work_loop->removeEventSource(interrupt_source);
     }
-    
+
     if (interrupt_simulator) {
         work_loop->removeEventSource(interrupt_simulator);
     }
@@ -146,7 +146,7 @@ void RMII2C::releaseResources() {
             device_nub->close(this);
         device_nub = nullptr;
     }
-    
+
     OSSafeReleaseNULL(command_gate);
     OSSafeReleaseNULL(interrupt_source);
     OSSafeReleaseNULL(interrupt_simulator);


### PR DESCRIPTION
Removing/adding interrupts during sleep can cause issues with pinning on newer Cannonlake devices. These changes come from https://github.com/VoodooI2C/VoodooI2CHID/commit/9b12ce5e79a4139d125489a3e76b8fedc8fbd337, and make sense to me.

I would like someone to verify that this works and doesn't cause any panics when loading/unloading the kext.

@zhen-zen would you mind taking a look at this?
