### PR TITLE
(Hopefully) fix stuck buttons

### DIFF
--- a/VoodooRMI/Functions/F30.cpp
+++ b/VoodooRMI/Functions/F30.cpp
@@ -204,6 +204,7 @@ int F30::rmi_f30_map_gpios()
     unsigned int button = BTN_LEFT;
     unsigned int trackpoint_button = BTN_LEFT;
     int buttonArrLen = min(gpioled_count, TRACKPOINT_RANGE_END);
+    const gpio_data *gpio = rmiBus->getGPIOData();
     setProperty("Button Count", buttonArrLen, 32);
     
     gpioled_key_map = reinterpret_cast<uint16_t *>(IOMalloc(buttonArrLen * sizeof(gpioled_key_map[0])));
@@ -213,8 +214,9 @@ int F30::rmi_f30_map_gpios()
         if (!rmi_f30_is_valid_button(i))
             continue;
         
-        if (i >= TRACKPOINT_RANGE_START && i < TRACKPOINT_RANGE_END) {
-            IOLogDebug("F30: Found Trackpoint button %d\n", button);
+        if (gpio->trackpointButtons &&
+            (i >= TRACKPOINT_RANGE_START && i < TRACKPOINT_RANGE_END)) {
+            IOLogDebug("F30: Found Trackpoint button %d\n", trackpoint_button);
             gpioled_key_map[i] = trackpoint_button++;
         } else {
             IOLogDebug("F30: Found Button %d", button);

--- a/VoodooRMI/Functions/F3A.cpp
+++ b/VoodooRMI/Functions/F3A.cpp
@@ -66,6 +66,7 @@ bool F3A::mapGpios(u8 *query1_regs, u8 *ctrl1_regs)
 {
     unsigned int button = BTN_LEFT;
     unsigned int trackpoint_button = BTN_LEFT;
+    const gpio_data *gpio = rmiBus->getGPIOData();
     numButtons = min(gpioCount, TRACKPOINT_RANGE_END);
     
     setProperty("Button Count", gpioCount, 32);
@@ -82,7 +83,8 @@ bool F3A::mapGpios(u8 *query1_regs, u8 *ctrl1_regs)
         if (!is_valid_button(i, query1_regs, ctrl1_regs))
             continue;
         
-        if (i >= TRACKPOINT_RANGE_START && i < TRACKPOINT_RANGE_END) {
+        if (gpio->trackpointButtons &&
+            (i >= TRACKPOINT_RANGE_START && i < TRACKPOINT_RANGE_END)) {
             IOLogDebug("F3A: Found Trackpoint button %d\n", trackpoint_button);
             gpioled_key_map[i] = trackpoint_button++;
         } else {

--- a/VoodooRMI/RMIBus.cpp
+++ b/VoodooRMI/RMIBus.cpp
@@ -50,9 +50,7 @@ RMIBus * RMIBus::probe(IOService *provider, SInt32 *score) {
     // GPIO data from VoodooPS2
     if (OSObject *object = transport->getProperty("GPIO Data")) {
         OSDictionary *dict = OSDynamicCast(OSDictionary, object);
-        if (dict) {
-            getGPIOData(dict);
-        }
+        getGPIOData(dict);
     }
 
     if (rmi_driver_probe(this)) {
@@ -409,6 +407,9 @@ void RMIBus::updateConfiguration(OSDictionary* dictionary) {
 }
 
 void RMIBus::getGPIOData(OSDictionary *dict) {
+    if (!dict)
+        return;
+    
     Configuration::loadBoolConfiguration(dict, "Clickpad", &gpio.clickpad);
     Configuration::loadBoolConfiguration(dict, "TrackstickButtons", &gpio.trackpointButtons);
     

--- a/VoodooRMI/RMIBus.cpp
+++ b/VoodooRMI/RMIBus.cpp
@@ -46,6 +46,14 @@ RMIBus * RMIBus::probe(IOService *provider, SInt32 *score) {
         IOLogError("Could not get transport instance");
         return NULL;
     }
+    
+    // GPIO data from VoodooPS2
+    if (OSObject *object = transport->getProperty("GPIO Data")) {
+        OSDictionary *dict = OSDynamicCast(OSDictionary, object);
+        if (dict) {
+            getGPIOData(dict);
+        }
+    }
 
     if (rmi_driver_probe(this)) {
         IOLogError("Could not probe");
@@ -398,4 +406,13 @@ void RMIBus::updateConfiguration(OSDictionary* dictionary) {
     } else {
         IOLogError("Invalid Configuration");
     }
+}
+
+void RMIBus::getGPIOData(OSDictionary *dict) {
+    Configuration::loadBoolConfiguration(dict, "Clickpad", &gpio.clickpad);
+    Configuration::loadBoolConfiguration(dict, "TrackstickButtons", &gpio.trackpointButtons);
+    
+    setProperty("GPIO Data", dict);
+    
+    IOLogInfo("Recieved GPIO Data");
 }

--- a/VoodooRMI/RMIBus.hpp
+++ b/VoodooRMI/RMIBus.hpp
@@ -49,8 +49,10 @@ public:
     IOReturn message(UInt32 type, IOService *provider, void *argument = 0) override;
     IOReturn setProperties(OSObject* properties) override;
 
+    // TODO: Clean up pointers
     rmi_driver_data *data;
     RMITransport *transport;
+    gpio_data gpio;
     bool awake {true};
     
     // rmi_read
@@ -76,6 +78,10 @@ public:
         return &voodooInputInstance;
     }
     
+    inline const gpio_data* getGPIOData() {
+        return &gpio;
+    }
+    
     OSSet *functions;
     
     void notify(UInt32 type, unsigned int argument = 0);
@@ -85,7 +91,8 @@ private:
     IOWorkLoop *workLoop {nullptr};
     IOCommandGate *commandGate {nullptr};
     IOService *voodooInputInstance {nullptr};
-
+    
+    void getGPIOData(OSDictionary *dict);
     void updateConfiguration(OSDictionary *dictionary);
     rmi_configuration conf {};
 

--- a/VoodooRMI/Transports/SMBus/RMISMBus.cpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.cpp
@@ -66,7 +66,12 @@ bool RMISMBus::start(IOService *provider)
                 return true;
             }
             
-            IOLogInfo("VoodooPS2Mouse finished init, starting...");
+            if (OSObject *gpio = newService->getProperty("GPIO Data")) {
+                IOLogDebug("Found GPIO data!");
+                setProperty("GPIO Data", gpio);
+            }
+            
+            IOLogInfo("VoodooPS2Trackpad finished init, starting...");
             messageClient(kPS2M_SMBusStart, newService);
             notifier->remove();
             rmiStart();

--- a/VoodooRMI/rmi.h
+++ b/VoodooRMI/rmi.h
@@ -140,6 +140,12 @@ struct rmi_configuration {
     uint64_t disableWhileTrackpointTimeout {2000};
 };
 
+// Data for F30 and F3A
+struct gpio_data {
+    bool clickpad {false};
+    bool trackpointButtons {true}; // Does not affect F03
+};
+
 /*
  *  Wrapper class for functions
  */


### PR DESCRIPTION
Fixes: #97 

Buttons have two sources: PS2 Passthrough (F03), or GPIO functions (F30/F3A).
The GPIO functions can have buttons which say they are there but are misconfigured or are not there. This can be seen as two additional buttons which are reported within the indexes for trackpoint buttons, but are always pulled low. VoodooPS2 correctly reports whether trackpoint buttons through GPIO functions should exist or not, so we use this data now when mapping to just ignore the trackpoint button indexes.