### PR TITLE
Reject fingers in zone always, except when moving finger out of zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,17 @@ The values below can be edited under Info.plist within the kext itself - these c
 | ----- | ------- | ----------- |
 | `ForceTouchEmulation` | True | Allows Force Touch emulation on Clickpads |
 | `ForceTouchMinPressure` | 90 | Minimum z value to trigger Force touch when clickpad is clicked |
-| `DisableWhileTypingTimeout` | 100 | Milliseconds after typing in which to reject trackpad packets |
+| `DisableWhileTypingTimeout` | 250 | Milliseconds after typing in which to reject trackpad packets |
+| `DisableWhileTrackpointTimeout` | 250 | Milliseconds after using the trackpoint in which to reject trackpad packets |
 | `TrackpointMultiplier` | 20 | Multiplier used on trackpoint inputs (other than scrolling). This is divided by 20, so the default value of 20 will not change the output value at all |
-| `TrackpointScrollMultiplierX` | 20 | Multiplier used on the x access when middle button is held down for scrolling. This is divded by 20. |
+| `TrackpointScrollMultiplierX` | 20 | Multiplier used on the x axis when middle button is held down for scrolling. This is divided by 20. |
 | `TrackpointScrollMultiplierY` | 20 | Same as the above, except applied to the Y axis |
 | `TrackpointDeadzone` | 1 | Minimum value at which trackpoint reports will be accepted. This is subtracted from the input of the trackpoint, so setting this extremely high will reduce trackpoint resolution |
 | `MinYDiffThumbDetection` | 200 | Minimum distance between the second lowest and lowest finger in which Minimum Y logic is used to detect the thumb rather than using the z value from the trackpad. Setting this higher means that the thumb must be farther from the other fingers before the y coordinate is used to detect the thumb, rather than using finger area. Keeping this smaller is preferable as finger area logic seems to only be useful when all 4 fingers are grouped together closely, where the thumb is more likely to be pressing down more |
+| `FingerMajorMinorDiffMax` | 10 | Max difference between the width and height of a touch input before it's invalid |
+| `PalmRejectionWidth` | 10 | Percent (out of 100) width of trackpad which is used for palm rejection on the left and right side of the trackpad |
+| `PalmRejectionWidth` | 60 | Percent (out of 100) height of trackpad which is used for palm rejection on the left and right side of the trackpad (starting from the top) |
+| `PalmRejectionTrackpointHeight` | 20 | Percent (out of 100) height of trackpad which is used for palm rejection across the top of the trackpad |
 
 Note that you can use Rehabman's ioio to set properties temporarily (until the next reboot).  
 `ioio -s RMIBus ForceTouchEmulation false`
@@ -170,6 +175,6 @@ If the above are loading, next place to check is within the IORegistry and withi
     * IORegs can be be saved using `File -> Save As` in the top left
 2) Get logs from within macOS
     * If loading VoodooRMI using `kextload` or `kextutil` within macOS, you can use `sudo log show --last boot | grep VRMI`
-    * If injecting through OpenCore/Clover, you will want to add the boot arg `msgbuf=1048576` and use `sudo dmesg | grep VRMI` immediately after booting with the boot arg.
+    * If injecting through OpenCore/Clover, you will want to either use DebugEnhancer.kext or add the boot arg `msgbuf=1048576`. Once in macOS, use `sudo dmesg | grep VRMI` immediately after booting to get the logs.
 
 When creating an issue, you will need to provide log files (IORegs not required but helpful)!

--- a/VoodooRMI.xcodeproj/project.pbxproj
+++ b/VoodooRMI.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 		A4560EBE247F29EC0009CBE0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1240;
 				ORGANIZATIONNAME = 1Revenger1;
 				TargetAttributes = {
 					6F4B4A8C24C1A0B80018F1F0 = {

--- a/VoodooRMI.xcodeproj/xcshareddata/xcschemes/RMISMBus.xcscheme
+++ b/VoodooRMI.xcodeproj/xcshareddata/xcschemes/RMISMBus.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/VoodooRMI.xcodeproj/xcshareddata/xcschemes/VoodooRMI.xcscheme
+++ b/VoodooRMI.xcodeproj/xcshareddata/xcschemes/VoodooRMI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/VoodooRMI/Functions/F11.hpp
+++ b/VoodooRMI/Functions/F11.hpp
@@ -532,6 +532,9 @@ private:
     bool has_acm;
     struct f11_2d_ctrl dev_controls;
     u16 rezero_wait_ms;
+    u8 *data_pkt { nullptr };
+    size_t pkt_size;
+    size_t attn_size;
     RMI2DSensor *sensor;
     struct f11_2d_sensor_queries sens_query;
     struct f11_2d_data data_2d;

--- a/VoodooRMI/Functions/F12.hpp
+++ b/VoodooRMI/Functions/F12.hpp
@@ -75,6 +75,9 @@ private:
     int rmi_f12_config();
     
     /* F12 Data */
+    u8 *data_pkt;
+    size_t pkt_size;
+    size_t attn_size;
     RMI2DSensor *sensor;
     struct rmi_2d_sensor_platform_data sensor_pdata;
     bool has_dribble;

--- a/VoodooRMI/Info.plist
+++ b/VoodooRMI/Info.plist
@@ -31,7 +31,7 @@
 				<key>DisableWhileTypingTimeout</key>
 				<integer>250</integer>
 				<key>FingerMajorMinorDiffMax</key>
-				<integer>3</integer>
+				<integer>10</integer>
 				<key>MinYDiffThumbDetection</key>
 				<integer>200</integer>
 				<key>ForceTouchEmulation</key>
@@ -46,6 +46,12 @@
 				<integer>30</integer>
 				<key>TrackpointScrollMultiplierY</key>
 				<integer>30</integer>
+				<key>PalmRejectionWidth</key>
+				<integer>15</integer>
+				<key>PalmRejectionHeight</key>
+				<integer>80</integer>
+				<key>PalmRejectionTrackpointHeight</key>
+				<integer>20</integer>
 			</dict>
 			<key>IOClass</key>
 			<string>RMIBus</string>

--- a/VoodooRMI/Info.plist
+++ b/VoodooRMI/Info.plist
@@ -47,9 +47,9 @@
 				<key>TrackpointScrollMultiplierY</key>
 				<integer>30</integer>
 				<key>PalmRejectionWidth</key>
-				<integer>15</integer>
+				<integer>10</integer>
 				<key>PalmRejectionHeight</key>
-				<integer>80</integer>
+				<integer>60</integer>
 				<key>PalmRejectionTrackpointHeight</key>
 				<integer>20</integer>
 			</dict>

--- a/VoodooRMI/RMIBus.cpp
+++ b/VoodooRMI/RMIBus.cpp
@@ -390,6 +390,9 @@ void RMIBus::updateConfiguration(OSDictionary* dictionary) {
     update |= Configuration::loadBoolConfiguration(dictionary, "ForceTouchEmulation", &conf.forceTouchEmulation);
     update |= Configuration::loadUInt32Configuration(dictionary, "MinYDiffThumbDetection", &conf.minYDiffGesture);
     update |= Configuration::loadUInt32Configuration(dictionary, "FingerMajorMinorDiffMax", &conf.fingerMajorMinorMax);
+    update |= Configuration::loadUInt8Configuration(dictionary, "PalmRejectionWidth", &conf.palmRejectionWidth);
+    update |= Configuration::loadUInt8Configuration(dictionary, "PalmRejectionHeight", &conf.palmRejectionHeight);
+    update |= Configuration::loadUInt8Configuration(dictionary, "PalmRejectionTrackpointHeight", &conf.palmRejectionHeightTrackpoint);
 
     if (update) {
         IOLogDebug("Updating Configuration");

--- a/VoodooRMI/RMI_2D_Sensor.cpp
+++ b/VoodooRMI/RMI_2D_Sensor.cpp
@@ -62,8 +62,6 @@ bool RMI2DSensor::start(IOService *provider)
     setProperty(VOODOO_INPUT_PHYSICAL_MAX_Y_KEY, y_mm * 100, 16);
     setProperty(VOODOO_INPUT_TRANSFORM_KEY, 0ull, 32);
     
-    mid_x = max_x / 2;
-    
     // VoodooPS2 keyboard notifs
     setProperty("RM,deliverNotifications", kOSBooleanTrue);
     setProperty("VoodooInputSupported", kOSBooleanTrue);

--- a/VoodooRMI/RMI_2D_Sensor.cpp
+++ b/VoodooRMI/RMI_2D_Sensor.cpp
@@ -356,11 +356,17 @@ MT2FingerType RMI2DSensor::getFingerType()
     return kMT2FingerTypeUndefined;
 }
 
+/**
+ * RMI2DSensor::invalidateFingers
+ * Invalidate fingers which are in zones currently
+ * Used when keyboard or trackpoint send events
+ */
 void RMI2DSensor::invalidateFingers() {
     for (size_t i = 0; i < MAX_FINGERS; i++) {
         VoodooInputTransducer &finger = inputEvent.transducers[i];
         
-        if (fingerState[i] == RMI_FINGER_INVALID)
+        if (fingerState[i] == RMI_FINGER_LIFTED ||
+            fingerState[i] == RMI_FINGER_INVALID)
             continue;
         
         if (checkInZone(finger))

--- a/VoodooRMI/RMI_2D_Sensor.hpp
+++ b/VoodooRMI/RMI_2D_Sensor.hpp
@@ -47,7 +47,7 @@ struct rmi_2d_sensor_abs_object {
 
 struct RMI2DSensorReport {
     rmi_2d_sensor_abs_object objs[10];
-    int fingers;
+    size_t fingers;
     AbsoluteTime timestamp;
 };
 
@@ -69,9 +69,6 @@ struct RMI2DSensorZone {
  * @max_x - The maximum X coordinate that will be reported by this sensor.
  * @max_y - The maximum Y coordinate that will be reported by this sensor.
  * @nbr_fingers - How many fingers can this sensor report?
- * @data_pkt - buffer for data reported by this sensor.
- * @pkt_size - number of bytes in that buffer.
- * @attn_size - Size of the HID attention report (only contains abs data).
  * position when two fingers are on the device.  When this is true, we
  * assume we have one of those sensors and report events appropriately..
  */
@@ -85,10 +82,6 @@ public:
     u8 x_mm;
     u8 y_mm;
     
-    u8 *data_pkt;
-    int pkt_size;
-    int attn_size;
-    
     u8 report_abs {0};
     u8 report_rel {0};
     
@@ -101,7 +94,6 @@ public:
     bool handleOpen(IOService *forClient, IOOptionBits options, void *arg) override;
     void handleClose(IOService *forClient, IOOptionBits options) override;
     IOReturn message(UInt32 type, IOService *provider, void *argument = 0) override;
-    void free() override;
     
     bool shouldDiscardReport(AbsoluteTime timestamp);
 private:
@@ -116,21 +108,9 @@ private:
 
     MT2FingerType getFingerType();
     bool checkInZone(VoodooInputTransducer &obj);
-    void setThumbFingerType(int fingers, RMI2DSensorReport *report);
+    void setThumbFingerType(size_t fingers, RMI2DSensorReport *report);
     void handleReport(RMI2DSensorReport *report);
-
-    // TODO: move into cpp file
-    inline void invalidateFingers() {
-        for (int i = 0; i < 5; i++) {
-            VoodooInputTransducer &finger = inputEvent.transducers[i];
-            
-            if (fingerState[i] == RMI_FINGER_INVALID)
-                continue;
-            
-            if (checkInZone(finger))
-                fingerState[i] = RMI_FINGER_INVALID;
-        }
-    }
+    void invalidateFingers();
 };
 
 #endif /* RMI_2D_Sensor_hpp */

--- a/VoodooRMI/RMI_2D_Sensor.hpp
+++ b/VoodooRMI/RMI_2D_Sensor.hpp
@@ -79,7 +79,6 @@ public:
     u16 min_y{0};
     u16 max_x;
     u16 max_y;
-    u16 mid_x;
     u8 x_mm;
     u8 y_mm;
     

--- a/VoodooRMI/RMI_2D_Sensor.hpp
+++ b/VoodooRMI/RMI_2D_Sensor.hpp
@@ -79,6 +79,7 @@ public:
     u16 min_y{0};
     u16 max_x;
     u16 max_y;
+    u16 mid_x;
     u8 x_mm;
     u8 y_mm;
     
@@ -101,7 +102,7 @@ private:
     RMI2DSensorZone rejectZones[3];
     
     bool freeFingerTypes[kMT2FingerTypeCount];
-    finger_state fingerState[MAX_FINGERS] { RMI_FINGER_LIFTED };
+    finger_state fingerState[MAX_FINGERS];
     bool clickpadState {false};
     bool trackpadEnable {true};
     uint64_t lastKeyboardTS {0}, lastTrackpointTS {0};

--- a/VoodooRMI/Utility/Configuration.cpp
+++ b/VoodooRMI/Utility/Configuration.cpp
@@ -38,3 +38,13 @@ bool Configuration::loadUInt32Configuration(OSDictionary *dict, const char* conf
     *defaultValue = value->unsigned32BitValue();
     return true;
 }
+
+bool Configuration::loadUInt8Configuration(OSDictionary *dict, const char* configurationKey, UInt8 *defaultValue) {
+    OSNumber* value;
+    if (!dict || nullptr == (value = OSDynamicCast(OSNumber, dict->getObject(configurationKey))))
+        return false;
+
+    IOLogDebug("Config %s loaded: %x -> %x", configurationKey, *defaultValue, value->unsigned8BitValue());
+    *defaultValue = value->unsigned8BitValue();
+    return true;
+}

--- a/VoodooRMI/Utility/Configuration.hpp
+++ b/VoodooRMI/Utility/Configuration.hpp
@@ -39,6 +39,7 @@ class Configuration {
     
 public:
     static bool loadBoolConfiguration(OSDictionary *dict, const char* configurationKey, bool *defaultValue);
+    static bool loadUInt8Configuration(OSDictionary *dict, const char* configurationKey, UInt8 *defaultValue);
     static bool loadUInt32Configuration(OSDictionary *dict, const char *configurationKey, UInt32 *defaultValue);
     static bool loadUInt64Configuration(OSDictionary *dict, const char* configurationKey, UInt64 *defaultValue);
     

--- a/VoodooRMI/rmi.h
+++ b/VoodooRMI/rmi.h
@@ -135,10 +135,14 @@ struct rmi_configuration {
     bool forceTouchEmulation {true};
     uint32_t forceTouchMinPressure {80};
     uint32_t minYDiffGesture {200};
-    uint32_t fingerMajorMinorMax {3};
+    uint32_t fingerMajorMinorMax {10};
     // Time units are in milliseconds
     uint64_t disableWhileTypingTimeout {2000};
     uint64_t disableWhileTrackpointTimeout {2000};
+    // Percentage out of 100
+    uint8_t palmRejectionWidth {15};
+    uint8_t palmRejectionHeight {80};
+    uint8_t palmRejectionHeightTrackpoint {20};
 };
 
 // Data for F30 and F3A


### PR DESCRIPTION
Redo palm rejection to always reject fingers in the palm rejection zones. They become valid if they leave the zones, have significant x velocity, or when doing gestures with more than 2 fingers. They always become invalid (can cannot become valid) if the keyboard or trackpoint is used and the finger is within any of the rejection zones.

Data packet was moved out of RMI_2D_Sensor as well, as RMI_2D_Sensor never did anything with it.