### PR TITLE
Adjusted reset timer for ps2 to 7 seconds to help broken hp trackpads

### DIFF
--- a/VoodooRMI/Transports/SMBus/RMISMBus.cpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.cpp
@@ -51,7 +51,7 @@ bool RMISMBus::start(IOService *provider)
     // Do a reset over PS2 if possible
     // If ApplePS2Synaptics isn't there, we can *likely* assume that they did not inject VoodooPS2Trackpad
     // In which case, resetting isn't important unless it's a broken HP machine
-    auto ps2 = waitForMatchingService(dict, UInt64 (6) * kSecondScale);
+    auto ps2 = waitForMatchingService(dict, UInt64 (7) * kSecondScale);
     
     if (ps2) {
         // VoodooPS2Trackpad is currently initializing.


### PR DESCRIPTION
At the default 5s, hp trackpads don't attach to VoodooPS2Trackpad properly, so increased to 7 gives enough time to attach it seems.  Only tested on HP ProBook 650 G2, booting fresh and from Windows BootCamp no instabilities.