### PR TITLE
Better PS2 Interactions 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "Dependencies/VoodooSMBus"]
 	path = Dependencies/VoodooSMBus
-	url = https://github.com/VoodooSMBus/VoodooSMBus.git
+	url = https://github.com/1Revenger1/VoodooSMBus.git
+	branch = ps2coop
 [submodule "Dependencies/VoodooI2C"]
 	path = Dependencies/VoodooI2C
 	url = https://github.com/VoodooI2C/VoodooI2C.git

--- a/VoodooRMI/Transports/SMBus/RMISMBus.cpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.cpp
@@ -92,6 +92,9 @@ bool RMISMBus::makePS2DriverBowToUs() {
     IOService *ps2Controller = waitForMatchingService(ps2contDict);
     IOService *ps2Trackpad = waitForMatchingService(trackpadDict);
     
+    OSSafeReleaseNULL(trackpadDict);
+    OSSafeReleaseNULL(ps2contDict);
+    
     if (ps2Trackpad == nullptr || ps2Controller == nullptr) {
         IOLogError("Could not find PS2 Trackpad driver! Aborting...");
         OSSafeReleaseNULL(ps2Trackpad);

--- a/VoodooRMI/Transports/SMBus/RMISMBus.cpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.cpp
@@ -56,11 +56,10 @@ bool RMISMBus::start(IOService *provider)
     
     if (!device_nub->createPS2Stub("ApplePS2SynapticsTouchPad", "GPIO Data", &ps2Controller)) {
         IOLogError("Could not create PS2 Stub!");
-        OSSafeReleaseNULL(ps2Controller);
         return false;
     }
     
-    OSDictionary *gpio = device_nub->grabPS2Info();
+    OSDictionary *gpio = device_nub->getPS2Info();
     if (gpio != nullptr) {
         IOLogInfo("Found PS/2 GPIO Data");
         setProperty("GPIO Data", gpio);
@@ -69,11 +68,13 @@ bool RMISMBus::start(IOService *provider)
     version = rmi_smb_get_version();
     if (version < 0) {
         IOLogError("Error: Failed to read SMBus version. Code: 0x%02X", version);
+        OSSafeReleaseNULL(ps2Controller);
         return false;
     }
     
     if (version != 2 && version != 3) {
         IOLogError("Unrecognized SMB Version %d", version);
+        OSSafeReleaseNULL(ps2Controller);
         return false;
     }
     

--- a/VoodooRMI/Transports/SMBus/RMISMBus.cpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.cpp
@@ -125,7 +125,7 @@ bool RMISMBus::makePS2DriverBowToUs() {
     }
     
     // Kill PS/2 driver and replace it with a stub to do our own bidding (heheheh)
-    const OSSymbol *funcName = OSSymbol::withCString("replaceTrackpadWithSMBusStub");
+    const OSSymbol *funcName = OSSymbol::withCString("PS2CreateSMBusStub");
     IOReturn ret = ps2Controller->callPlatformFunction(funcName,
                                                        true,
                                                        reinterpret_cast<void *>(ps2PortNum->unsigned8BitValue()),
@@ -416,4 +416,13 @@ OSDictionary *RMISMBus::createConfig() {
     OSSafeReleaseNULL(acpiReturn);
     
     return config;
+}
+
+IOReturn RMISMBus::powerStateWillChangeTo(IOPMPowerFlags capabilities, unsigned long stateNumber, IOService *whatDevice) {
+    return kIOPMAckImplied;
+}
+
+IOReturn RMISMBus::powerStateDidChangeTo(IOPMPowerFlags capabilities, unsigned long stateNumber, IOService *whatDevice) {
+    // Do stuff here. Only reinit when PS/2 is ready and SMBus is ready
+    return kIOPMAckImplied;
 }

--- a/VoodooRMI/Transports/SMBus/RMISMBus.cpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.cpp
@@ -369,21 +369,7 @@ IOReturn RMISMBus::setPowerState(unsigned long whichState, IOService* whatDevice
         messageClient(kIOMessageRMI4Sleep, bus);
     } else {
         // FIXME: Hardcode 1s sleep delay because device will otherwise time out during reconfig
-        IOSleep(1000);
-        
-        // Put trackpad in SMBus mode again
-        int retval = reset();
-        if (retval < 0) {
-            IOLogError("Failed to reset trackpad!");
-            return kIOPMAckImplied;
-        }
-        
-        // Reconfigure and enable trackpad again
-        retval = messageClient(kIOMessageRMI4Resume, bus);
-        if (retval < 0) {
-            IOLogError("Failed to resume trackpad!");
-            return kIOPMAckImplied;
-        }
+//        IOSleep(1000);
     }
 
     return kIOPMAckImplied;
@@ -426,6 +412,22 @@ IOReturn RMISMBus::powerStateWillChangeTo(IOPMPowerFlags capabilities, unsigned 
 }
 
 IOReturn RMISMBus::powerStateDidChangeTo(IOPMPowerFlags capabilities, unsigned long stateNumber, IOService *whatDevice) {
-    // Do stuff here. Only reinit when PS/2 is ready and SMBus is ready
+    // TODO: Do stuff here. Only reinit when PS/2 is ready and SMBus is ready
+    IOLogDebug("PS2 Ready! Reinitializing...");
+    
+    // Put trackpad in SMBus mode again
+    int retval = reset();
+    if (retval < 0) {
+        IOLogError("Failed to reset trackpad!");
+        return kIOPMAckImplied;
+    }
+    
+    // Reconfigure and enable trackpad again
+    retval = messageClient(kIOMessageRMI4Resume, bus);
+    if (retval < 0) {
+        IOLogError("Failed to resume trackpad!");
+        return kIOPMAckImplied;
+    }
+    
     return kIOPMAckImplied;
 }

--- a/VoodooRMI/Transports/SMBus/RMISMBus.cpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.cpp
@@ -413,20 +413,22 @@ IOReturn RMISMBus::powerStateWillChangeTo(IOPMPowerFlags capabilities, unsigned 
 
 IOReturn RMISMBus::powerStateDidChangeTo(IOPMPowerFlags capabilities, unsigned long stateNumber, IOService *whatDevice) {
     // TODO: Do stuff here. Only reinit when PS/2 is ready and SMBus is ready
-    IOLogDebug("PS2 Ready! Reinitializing...");
     
-    // Put trackpad in SMBus mode again
-    int retval = reset();
-    if (retval < 0) {
-        IOLogError("Failed to reset trackpad!");
-        return kIOPMAckImplied;
-    }
-    
-    // Reconfigure and enable trackpad again
-    retval = messageClient(kIOMessageRMI4Resume, bus);
-    if (retval < 0) {
-        IOLogError("Failed to resume trackpad!");
-        return kIOPMAckImplied;
+    if (capabilities & kIOPMPowerOn) {
+        IOLogDebug("PS2 Ready! Reinitializing...");
+        // Put trackpad in SMBus mode again
+        int retval = reset();
+        if (retval < 0) {
+            IOLogError("Failed to reset trackpad!");
+            return kIOPMAckImplied;
+        }
+        
+        // Reconfigure and enable trackpad again
+        retval = messageClient(kIOMessageRMI4Resume, bus);
+        if (retval < 0) {
+            IOLogError("Failed to resume trackpad!");
+            return kIOPMAckImplied;
+        }
     }
     
     return kIOPMAckImplied;

--- a/VoodooRMI/Transports/SMBus/RMISMBus.hpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.hpp
@@ -25,6 +25,11 @@ struct mapping_table_entry {
     UInt8 flags;
 };
 
+enum {
+    kRMIPowerOn = 0x01,
+    kRMIAckPwr  = 0x02,
+};
+
 class RMISMBus : public RMITransport {
     OSDeclareDefaultStructors(RMISMBus);
     
@@ -49,6 +54,7 @@ private:
     VoodooSMBusDeviceNub *device_nub;
     IOLock *page_mutex;
     IOLock *mapping_table_mutex;
+    UInt8 powerFlags {kRMIPowerOn};
     
     struct mapping_table_entry mapping_table[RMI_SMB2_MAP_SIZE];
     UInt8 table_index {0};

--- a/VoodooRMI/Transports/SMBus/RMISMBus.hpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.hpp
@@ -51,6 +51,7 @@ public:
     int reset() override;
     virtual OSDictionary *createConfig() APPLE_KEXT_OVERRIDE;
 private:
+    IOService *ps2Controller;
     VoodooSMBusDeviceNub *device_nub;
     IOLock *page_mutex;
     IOLock *mapping_table_mutex;
@@ -59,8 +60,6 @@ private:
     struct mapping_table_entry mapping_table[RMI_SMB2_MAP_SIZE];
     UInt8 table_index {0};
     
-    bool acidantheraTrackpadExists(void);
-    bool makePS2DriverBowToUs(void);
     int rmi_smb_get_version();
     int rmi_smb_get_command_code(UInt16 rmiaddr, int bytecount,
                                  bool isread, UInt8 *commandcode);

--- a/VoodooRMI/Transports/SMBus/RMISMBus.hpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.hpp
@@ -37,6 +37,9 @@ public:
     void stop(IOService *provider) override;
     void free() override;
     
+    IOReturn powerStateDidChangeTo(IOPMPowerFlags, unsigned long, IOService *) override;
+    IOReturn powerStateWillChangeTo(IOPMPowerFlags, unsigned long, IOService *) override;
+    
     int readBlock(UInt16 rmiaddr, UInt8 *databuff, size_t len) override;
     int blockWrite(UInt16 rmiaddr, UInt8 *buf, size_t len) override;
     

--- a/VoodooRMI/Transports/SMBus/RMISMBus.hpp
+++ b/VoodooRMI/Transports/SMBus/RMISMBus.hpp
@@ -50,7 +50,8 @@ private:
     struct mapping_table_entry mapping_table[RMI_SMB2_MAP_SIZE];
     UInt8 table_index {0};
     
-    bool rmiStart();
+    bool acidantheraTrackpadExists(void);
+    bool makePS2DriverBowToUs(void);
     int rmi_smb_get_version();
     int rmi_smb_get_command_code(UInt16 rmiaddr, int bytecount,
                                  bool isread, UInt8 *commandcode);


### PR DESCRIPTION
Smarter detection for VoodooPS2Trackpad and terminates VoodooPS2Trackpad instead of just disabling. Also registers a listener for any power state changes on the ps2 controller.