### PR TITLE
Set contact count to max number of fingers

### DIFF
--- a/VoodooRMI/Functions/Input/RMITrackpadFunction.cpp
+++ b/VoodooRMI/Functions/Input/RMITrackpadFunction.cpp
@@ -280,7 +280,7 @@ void RMITrackpadFunction::handleReport(RMI2DSensorReport *report)
     }
     
     inputEvent.transducers[0].isPhysicalButtonDown = clickpadState;
-    inputEvent.contact_count = validFingerCount;
+    inputEvent.contact_count = maxIdx;
     inputEvent.timestamp = report->timestamp;
     
     sendVoodooInputPacket(kIOMessageVoodooInputMessage, &inputEvent);


### PR DESCRIPTION
Fixes #186 

If a finger is lifted (or tapped in quick succession), the current finger is not guaranteed to be in the first slot